### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ true
 | audio/x-wav  | wav       |
 | audio/amr    | amr       |
 | audio/aac    | aac       |
-| audio/aiff   | aiff      |
+| audio/x-aiff | aiff      |
 
 ### Document
 


### PR DESCRIPTION
I introduced a tiny typo in #1. Sorry for that. It's probably better to fix it in order to not confuse people.