### PR TITLE
Fix UnicodeConversionError

### DIFF
--- a/lib/matchers/text.ex
+++ b/lib/matchers/text.ex
@@ -19,6 +19,10 @@ defmodule Infer.Text do
       iex> Infer.Text.html?("<")
       false
 
+      iex> binary = File.read!("test/archives/sample.zip")
+      iex> Infer.Text.html?(binary)
+      false
+
   """
   @spec html?(binary()) :: boolean()
   def html?(binary) do
@@ -45,7 +49,7 @@ defmodule Infer.Text do
     char_list =
       binary
       |> String.trim()
-      |> String.to_charlist()
+      |> :binary.bin_to_list()
 
     Enum.any?(values, fn val ->
       if starts_with_ignore_ascii_case(char_list, val) do
@@ -62,19 +66,39 @@ defmodule Infer.Text do
   Takes the binary file contents as arguments. Returns `true` if it's xml.
 
   See: https://mimesniff.spec.whatwg.org/
+
+  ## Examples
+
+      iex> Infer.Text.xml?(~s(<?xml version="1.0" encoding="ISO-8859-1"?>))
+      true
+
+      iex> binary = File.read!("test/archives/sample.zip")
+      iex> Infer.Text.xml?(binary)
+      false
+
   """
   @spec xml?(binary()) :: boolean()
   def xml?(binary) do
     char_list =
       binary
       |> String.trim()
-      |> String.to_charlist()
+      |> :binary.bin_to_list()
 
     starts_with_ignore_ascii_case(char_list, '<?xml')
   end
 
   @doc """
   Takes the binary file contents as arguments. Returns `true` if it's a shell script.
+
+  ## Examples
+
+    iex> Infer.Text.shell_script?("#!/bin/sh")
+    true
+
+    iex> binary = File.read!("test/archives/sample.zip")
+    iex> Infer.Text.shell_script?(binary)
+    false
+
   """
   @spec shell_script?(binary()) :: boolean()
   def shell_script?(<<"#!", _rest::binary>>), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Infer.MixProject do
       app: :infer,
       version: "0.2.0",
       elixir: "~> 1.10",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
@@ -28,6 +29,9 @@ defmodule Infer.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/infer_test.exs
+++ b/test/infer_test.exs
@@ -11,4 +11,166 @@ defmodule InferTest do
   doctest Infer.Font
   doctest Infer.Text
   doctest Infer.Video
+
+  describe "Infer.App" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :app))
+
+    test "handles app files" do
+      for {_path, binary} <- TestFiles.list(only: :app) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-app files" do
+        for {path, binary} <- TestFiles.list(except: :app) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Book" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :book))
+
+    test "handles book files" do
+      for {_path, binary} <- TestFiles.list(only: :books) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-book files" do
+        for {path, binary} <- TestFiles.list(except: :books) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Image" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :image))
+
+    test "handles image files" do
+      for {_path, binary} <- TestFiles.list(only: :images) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-image files" do
+        for {path, binary} <- TestFiles.list(except: :images) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Video" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :video))
+
+    test "handles video files" do
+      for {_path, binary} <- TestFiles.list(only: :videos) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-video files" do
+        for {path, binary} <- TestFiles.list(except: :videos) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Audio" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :audio))
+
+    test "handles audio files" do
+      for {_path, binary} <- TestFiles.list(only: :audio) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-audio files" do
+        for {path, binary} <- TestFiles.list(except: :audio) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Font" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :font))
+
+    test "handles font files" do
+      for {_path, binary} <- TestFiles.list(only: :fonts) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-font files" do
+        for {path, binary} <- TestFiles.list(except: :fonts) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Doc" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :doc))
+
+    test "handles documnet files" do
+      for {_path, binary} <- TestFiles.list(only: :docs) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-document files" do
+        for {path, binary} <- TestFiles.list(except: :docs) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Archive" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :archive))
+
+    test "handles archive files" do
+      for {_path, binary} <- TestFiles.list(only: :archives) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-archive files" do
+        for {path, binary} <- TestFiles.list(except: [:archives, :docs, :books]) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
+
+  describe "Infer.Text" do
+    @matchers Infer.Matchers.list() |> Enum.filter(&(&1.matcher_type == :text))
+
+    test "handles text files" do
+      for {_path, binary} <- TestFiles.list(only: :text) do
+        assert Enum.find(@matchers, & &1.matcher.(binary))
+      end
+    end
+
+    for %Infer.Type{matcher: matcher} <- @matchers do
+      test "#{inspect(matcher)} handles non-text files" do
+        for {path, binary} <- TestFiles.list(except: :text) do
+          assert {_, false} = {path, unquote(matcher).(binary)}
+        end
+      end
+    end
+  end
 end

--- a/test/infer_test.exs
+++ b/test/infer_test.exs
@@ -1,5 +1,6 @@
 defmodule InferTest do
   use ExUnit.Case
+
   doctest Infer
   doctest Infer.App
   doctest Infer.Archive

--- a/test/support/test_files.ex
+++ b/test/support/test_files.ex
@@ -1,0 +1,23 @@
+defmodule TestFiles do
+  @types [:app, :archives, :audio, :books, :docs, :fonts, :images, :videos, :text]
+
+  @files (for type <- @types,
+              path <- Path.wildcard("test/#{type}/*") do
+            @external_resource Path.relative_to_cwd(path)
+
+            {type, {Path.basename(path), File.read!(path)}}
+          end)
+         |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+         |> Map.new()
+
+  def list(opts \\ [])
+  def list(only: only), do: Map.fetch!(@files, only)
+
+  def list(opts) do
+    except = List.wrap(opts[:except])
+
+    Map.take(@files, @types -- except)
+    |> Map.values()
+    |> List.flatten()
+  end
+end

--- a/test/text/sample.html
+++ b/test/text/sample.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>My First Heading</h1>
+    <p>My first paragraph.</p>
+  </body>
+</html>

--- a/test/text/sample.sh
+++ b/test/text/sample.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Hello World!"

--- a/test/text/sample.xml
+++ b/test/text/sample.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies,
+      an evil sorceress, and her own childhood to become queen
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology
+      society in England, the young survivors lay the
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious
+      agent known only as Oberon helps to create a new life
+      for the inhabitants of London. Sequel to Maeve
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters,
+      battle one another for control of England. Sequel to
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in
+      detail, with attention to XML DOM interfaces, XSLT processing,
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are
+      integrated into a comprehensive development
+      environment.</description>
+   </book>
+</catalog>


### PR DESCRIPTION
This fixes a `UnicodeConversionError` that gets raised by [String.to_charlist/1](https://hexdocs.pm/elixir/1.12/String.html#to_charlist/1) if `Infer.Text.html?` or `Infer.Text.xml?` receive a binary that is not  UTF-8 encoded.

```elixir
iex> String.to_charlist <<0xFF>>
** (UnicodeConversionError) invalid encoding starting at <<255>>
    (elixir 1.13.3) lib/string.ex:2407: String.to_charlist/1

iex> :binary.bin_to_list <<0xFF>>
[255]
```

I also added a bunch of `Infer.Matchers` tests for unexpected inputs, which increases the time to run the whole test suite a bit, mostly due to the size of some test files.

